### PR TITLE
remove legacy torch.autograd dependency

### DIFF
--- a/lecture_001/pytorch_square.py
+++ b/lecture_001/pytorch_square.py
@@ -38,7 +38,7 @@ print("Profiling torch.square")
 print("=============")
 
 # Now profile each function using pytorch profiler
-with torch.autograd.profiler.profile(use_cuda=True) as prof:
+with torch.profiler.profile() as prof:
     torch.square(b)
 
 print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=10))
@@ -47,7 +47,7 @@ print("=============")
 print("Profiling a * a")
 print("=============")
 
-with torch.autograd.profiler.profile(use_cuda=True) as prof:
+with torch.profiler.profile() as prof:
     square_2(b)
 
 print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=10))
@@ -56,7 +56,7 @@ print("=============")
 print("Profiling a ** 2")
 print("=============")
 
-with torch.autograd.profiler.profile(use_cuda=True) as prof:
+with torch.profiler.profile() as prof:
     square_3(b)
 
 print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=10))


### PR DESCRIPTION
This PR updates the torch.profiler to use the most recent stable API, following PyTorch's guidance on deprecating the older version of the profiler API. The [torch.profiler documentation](https://pytorch.org/docs/master/profiler.html) states that the previous API in the [torch.autograd](https://pytorch.org/docs/master/autograd.html#module-torch.autograd) module is considered legacy and will be deprecated in future releases.
To align with these changes, this PR transitions the code to the latest stable version of the torch.profiler API as outlined in the PyTorch 2.4 documentation [here](https://pytorch.org/docs/2.4/profiler.html#module-torch.profiler).
This ensures compatibility with future releases and follows best practices for CUDA-based profiling in PyTorch.