### PR TITLE
Fix bug in `triton_util.py`

### DIFF
--- a/lecture_014/triton_util.py
+++ b/lecture_014/triton_util.py
@@ -14,7 +14,7 @@ def test_pid_conds(conds, pid_0=[0], pid_1=[0], pid_2=[0]):
     for i, (cond, pid) in enumerate(zip(conds, pids)):
         if cond=='': continue
         op, threshold = cond[0], int(cond[1:])
-        if op not in ['<','>','>=','<=','=', '!=']: raise ValueError(f"Rules may only use these ops: '<','>','>=','<=','=', '!='. Invalid rule: '{condition}'.")
+        if op not in ['<','>','>=','<=','=', '!=']: raise ValueError(f"Rules may only use these ops: '<','>','>=','<=','=', '!='. Invalid rule: '{cond}'.")
         op = '==' if op == '=' else op
         if not eval(f'{pid} {op} {threshold}'): return False
     return True


### PR DESCRIPTION
# PR Summary
PR fixes a small bug in `triton_util.py` - instead of `condition` it should be `cond`.